### PR TITLE
Update Default Server Types to reflect new pricing and server types

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Example nodepool configuration:
 ```tf
 {
   name        = "egress",
-  server_type = "cpx11",
+  server_type = "cx22",
   location    = "fsn1",
   labels = [
     "node.kubernetes.io/role=egress"

--- a/README.md
+++ b/README.md
@@ -947,7 +947,7 @@ easily map between your nodes and your kube.tf file.
   agent_nodepools = [
     {
       name        = "agent-large",
-      server_type = "cpx21",
+      server_type = "cx32",
       location    = "nbg1",
       labels      = [],
       taints      = [],
@@ -960,7 +960,7 @@ easily map between your nodes and your kube.tf file.
         },
         "1" : {
           append_index_to_node_name = false,
-          server_type = "cpx31",
+          server_type = "cx42",
           labels = ["my.extra.label=slightlybiggernode"]
           placement_group = "agent-large-pg-2",
         },

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -186,7 +186,7 @@ module "kube-hetzner" {
     },
     {
       name        = "agent-large",
-      server_type = "cpx21",
+      server_type = "cx32",
       location    = "nbg1",
       labels      = [],
       taints      = [],
@@ -200,7 +200,7 @@ module "kube-hetzner" {
     },
     {
       name        = "storage",
-      server_type = "cpx21",
+      server_type = "cx32",
       location    = "fsn1",
       # Fully optional, just a demo.
       labels      = [
@@ -223,7 +223,7 @@ module "kube-hetzner" {
     # See the https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner#examples for an example use case.
     {
       name        = "egress",
-      server_type = "cx21",
+      server_type = "cx22",
       location    = "fsn1",
       labels = [
         "node.kubernetes.io/role=egress"
@@ -323,7 +323,7 @@ module "kube-hetzner" {
   # autoscaler_nodepools = [
   #   {
   #     name        = "autoscaled-small"
-  #     server_type = "cpx21"
+  #     server_type = "cx32"
   #     location    = "fsn1"
   #     min_nodes   = 0
   #     max_nodes   = 5

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -97,7 +97,7 @@ module "kube-hetzner" {
   # For instance, one is ok (non-HA), two is not ok, and three is ok (becomes HA). It does not matter if they are in the same nodepool or not! So they can be in different locations and of various types.
 
   # Of course, you can choose any number of nodepools you want, with the location you want. The only constraint on the location is that you need to stay in the same network region, Europe, or the US.
-  # For the server type, the minimum instance supported is cpx11 (just a few cents more than cx11) but the cax11 is even cheaper and more powerful (arm64); see https://www.hetzner.com/cloud.
+  # For the server type, the minimum instance supported is cx22. The cax11 provides even better value for money if your applications are compatible with arm64; see https://www.hetzner.com/cloud.
 
   # IMPORTANT: Before you create your cluster, you can do anything you want with the nodepools, but you need at least one of each, control plane and agent.
   # Once the cluster is up and running, you can change nodepool count and even set it to 0 (in the case of the first control-plane nodepool, the minimum is 1).
@@ -121,7 +121,7 @@ module "kube-hetzner" {
   control_plane_nodepools = [
     {
       name        = "control-plane-fsn1",
-      server_type = "cpx11",
+      server_type = "cx22",
       location    = "fsn1",
       labels      = [],
       taints      = [],
@@ -138,7 +138,7 @@ module "kube-hetzner" {
     },
     {
       name        = "control-plane-nbg1",
-      server_type = "cpx11",
+      server_type = "cx22",
       location    = "nbg1",
       labels      = [],
       taints      = [],
@@ -152,7 +152,7 @@ module "kube-hetzner" {
     },
     {
       name        = "control-plane-hel1",
-      server_type = "cpx11",
+      server_type = "cx22",
       location    = "hel1",
       labels      = [],
       taints      = [],
@@ -169,7 +169,7 @@ module "kube-hetzner" {
   agent_nodepools = [
     {
       name        = "agent-small",
-      server_type = "cpx11",
+      server_type = "cx22",
       location    = "fsn1",
       labels      = [],
       taints      = [],

--- a/packer-template/hcloud-microos-snapshots.pkr.hcl
+++ b/packer-template/hcloud-microos-snapshots.pkr.hcl
@@ -80,7 +80,7 @@ source "hcloud" "microos-x86-snapshot" {
   image       = "ubuntu-22.04"
   rescue      = "linux64"
   location    = "fsn1"
-  server_type = "cpx11" # disk size of >= 40GiB is needed to install the MicroOS image
+  server_type = "cx22" # disk size of >= 40GiB is needed to install the MicroOS image
   snapshot_labels = {
     microos-snapshot = "yes"
     creator          = "kube-hetzner"

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -47,13 +47,13 @@ fi
 
 # Download the required files only if they don't exist
 if [ ! -e "${folder_path}/kube.tf" ]; then
-    curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/kube.tf.example -o "${folder_path}/kube.tf"
+    curl -sL https://raw.githubusercontent.com/skyride/terraform-hcloud-kube-hetzner/update-default-server-types/kube.tf.example -o "${folder_path}/kube.tf"
 else
     echo "kube.tf already exists. Skipping download."
 fi
 
 if [ ! -e "${folder_path}/hcloud-microos-snapshots.pkr.hcl" ]; then
-    curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/packer-template/hcloud-microos-snapshots.pkr.hcl -o "${folder_path}/hcloud-microos-snapshots.pkr.hcl"
+    curl -sL https://raw.githubusercontent.com/skyride/terraform-hcloud-kube-hetzner/update-default-server-types/packer-template/hcloud-microos-snapshots.pkr.hcl -o "${folder_path}/hcloud-microos-snapshots.pkr.hcl"
 else
     echo "hcloud-microos-snapshots.pkr.hcl already exists. Skipping download."
 fi

--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -47,13 +47,13 @@ fi
 
 # Download the required files only if they don't exist
 if [ ! -e "${folder_path}/kube.tf" ]; then
-    curl -sL https://raw.githubusercontent.com/skyride/terraform-hcloud-kube-hetzner/update-default-server-types/kube.tf.example -o "${folder_path}/kube.tf"
+    curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/kube.tf.example -o "${folder_path}/kube.tf"
 else
     echo "kube.tf already exists. Skipping download."
 fi
 
 if [ ! -e "${folder_path}/hcloud-microos-snapshots.pkr.hcl" ]; then
-    curl -sL https://raw.githubusercontent.com/skyride/terraform-hcloud-kube-hetzner/update-default-server-types/packer-template/hcloud-microos-snapshots.pkr.hcl -o "${folder_path}/hcloud-microos-snapshots.pkr.hcl"
+    curl -sL https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/packer-template/hcloud-microos-snapshots.pkr.hcl -o "${folder_path}/hcloud-microos-snapshots.pkr.hcl"
 else
     echo "hcloud-microos-snapshots.pkr.hcl already exists. Skipping download."
 fi


### PR DESCRIPTION
Hetzner announced their new Intel cloud servers yesterday, CX22-CX52. They are much better value for money than the old Intel and even current AMD types. This PR updates the default templates to use CX22 and CX32 instances where CPX11 and CPX21 were used.

https://www.hetzner.com/news/new-cx-plans/

This has been tested by following through the tutorial and creating a new cluster from scratch. CX22 is used to create the x86 snapshot, and also as the default type in the generated `kube.tf`.

Hetzner will discontinue the old Intel server types in 6 months.